### PR TITLE
Error handling improvements

### DIFF
--- a/app/src/installer.js
+++ b/app/src/installer.js
@@ -26,7 +26,7 @@ global.installer = function() {
     install: function(zxpPath) {
 
       console.log("using target path of " + target_path());
-      console.log("startig to install ZXP from path " + zxpPath);
+      console.log("starting to install ZXP from path " + zxpPath);
 
       return promise = new Promise(function(resolve, reject) {
         var spawn = install_process.spawn(path.join(__dirname, target_path()), [CMD_PREFIX+"install", zxpPath]);

--- a/app/src/installer.js
+++ b/app/src/installer.js
@@ -38,7 +38,7 @@ global.installer = function() {
         });
 
         spawn.stderr.on('data',function(data){
-            console.log("stdout " + data.toString());
+            console.log("stderr " + data.toString());
             reject(data.toString());
         });
 

--- a/app/src/installer.js
+++ b/app/src/installer.js
@@ -32,8 +32,9 @@ global.installer = function() {
         var spawn = install_process.spawn(path.join(__dirname, target_path()), [CMD_PREFIX+"install", zxpPath]);
 
         spawn.stdout.on('data',function(data){
-            console.log("stdout " + data.toString());
-            reject(data.toString());
+            console.log('stderr: ' + data.toString());
+            var logbits = /-(\d+)/.exec(data.toString());
+            reject(logbits && logbits[1] ? parseInt(logbits[1]) : null);
         });
 
         spawn.stderr.on('data',function(data){

--- a/app/src/installer.js
+++ b/app/src/installer.js
@@ -37,8 +37,13 @@ global.installer = function() {
         });
 
         spawn.stderr.on('data',function(data){
-            console.log("stderr " + data.toString());
-            reject(data.toString());
+            console.log('stderr: ' + data.toString());
+            var logbits = /(\d{4}-\d{2}-\d{2}) (\d{2}:\d{2}:\d{2}) : ([A-Z]+)\s+(.*)/.exec(data.toString());
+            var date    = logbits[1];
+            var time    = logbits[2];
+            var level   = logbits[3];
+            var message = logbits[4];
+            if (level === 'ERROR') {reject(message);}
         });
 
         // code 0 => success

--- a/app/src/installer.js
+++ b/app/src/installer.js
@@ -31,7 +31,6 @@ global.installer = function() {
       return promise = new Promise(function(resolve, reject) {
         var spawn = install_process.spawn(path.join(__dirname, target_path()), [CMD_PREFIX+"install", zxpPath]);
 
-        // AEM only prints out if something went wrong. Adobe - go figure
         spawn.stdout.on('data',function(data){
             console.log("stdout " + data.toString());
             reject(data.toString());

--- a/app/src/main.js
+++ b/app/src/main.js
@@ -28,8 +28,13 @@ global.View = function() {
   }
 
   var installationFailed = function(error) {
+    var errors = {
+      402: 'Installation failed because the extension\'s signature is invalid.'
+      456: 'Please close all Adobe applications and try again.'
+    };
+
     view.removeChild(spinner.el);
-    $(view).find('.status').html(error);
+    $(view).find('.status').html(errors[error] || 'Error: ' + error);
   }
 
   var installationSuccess = function() {

--- a/app/src/main.js
+++ b/app/src/main.js
@@ -29,8 +29,16 @@ global.View = function() {
 
   var installationFailed = function(error) {
     var errors = {
-      402: 'Installation failed because the extension\'s signature is invalid.'
-      456: 'Please close all Adobe applications and try again.'
+      175: 'Installation failed because you do not have administrator access.',
+      201: 'Installation failed because the extension invalid.',
+      411: 'Installation failed because the extension is not compatible with the installed applications.',
+      407: 'Installation failed because this extension requires another extension.',
+      408: 'Installation failed because this extension requires another extension.',
+      412: 'Installation failed because an extension of the same name exists.',
+      418: 'Installation failed because a newer version of the extension is installed.',
+      456: 'Installation failed because Adobe applications are running',
+      458: 'Installation failed because none of the required applications are installed',
+      459: 'Installation failed because the extension is not compatible with the installed applications.'
     };
 
     view.removeChild(spinner.el);

--- a/app/src/main.js
+++ b/app/src/main.js
@@ -16,7 +16,6 @@ global.View = function() {
     promise.then(function(result) {
       installationSuccess();
     }, function(err) {
-      console.log(err); // Error
       installationFailed(err);
     });
 

--- a/app/src/main.js
+++ b/app/src/main.js
@@ -17,7 +17,7 @@ global.View = function() {
       installationSuccess();
     }, function(err) {
       console.log(err); // Error
-      installationFaild(err);
+      installationFailed(err);
     });
 
   }
@@ -27,7 +27,7 @@ global.View = function() {
     view.appendChild(spinner.el);
   }
 
-  var installationFaild = function(error) {
+  var installationFailed = function(error) {
     view.removeChild(spinner.el);
     $(view).find('.status').html(error);
   }

--- a/app/style.css
+++ b/app/style.css
@@ -11,7 +11,6 @@
   color: #bbbbbb;
   text-align: center;
   padding-top: 5px;
-  text-transform: capitalize;
 }
 #holder {
   background-image: url('assets/em.png');


### PR DESCRIPTION
In preparation for an upcoming UI pull request I'll be making, here are some error handling improvements.

1. I noticed that ExMan logs all debug output to `stderr`. Never mind the logic of that (heh), but this changes things up so it only exits when `stderr` actually throws an error message.

2. The output errors aren't particularly helpful. I've updated things to ignore the built in errors, parse out the error code, and set it up to be able to write human friendly error messages that are a bit more helpful, based on [Adobe's error codes](http://www.adobeexchange.com/resources/19#errors)